### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,5 +1,8 @@
 name: Test deployment
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sunflynf/web-notes/security/code-scanning/2](https://github.com/sunflynf/web-notes/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only performs basic CI tasks like dependency installation and website build testing, it requires minimal permissions. The `contents: read` permission is sufficient for these operations. The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
