### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/sunflynf/web-notes/security/code-scanning/1](https://github.com/sunflynf/web-notes/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `build` job. Since the `build` job only needs to read the repository contents (e.g., to check out the code and install dependencies), we will set `contents: read` as the permission. This ensures the `GITHUB_TOKEN` has the minimal privileges required for the job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
